### PR TITLE
Updated translate3d check to work with Chrome & IE

### DIFF
--- a/owl-carousel/owl.carousel.js
+++ b/owl-carousel/owl.carousel.js
@@ -803,7 +803,7 @@ if (typeof Object.create !== "function") {
                                   "; transform:"         + translate3D;
             regex = /translate3d\(0px, 0px, 0px\)/g;
             asSupport = tempElem.style.cssText.match(regex);
-            support3d = (asSupport !== null && asSupport.length === 1);
+            support3d = (asSupport !== null && asSupport.length !== 0);
 
             isTouch = "ontouchstart" in window || window.navigator.msMaxTouchPoints;
 


### PR DESCRIPTION
Chrome & IE support multiple syntaxes for `transform`. For instance, Chrome also supports `-webkit-transform`. I updated the check to allow for multiple matches, which fixes the issue in Chrome & IE.