### PR TITLE
Do not include elements with class `.owl-hidden`

### DIFF
--- a/owl-carousel/owl.carousel.js
+++ b/owl-carousel/owl.carousel.js
@@ -83,7 +83,7 @@ if (typeof Object.create !== "function") {
             if (base.$elem.children().length === 0) {return false; }
             base.baseClass();
             base.eventTypes();
-            base.$userItems = base.$elem.children();
+            base.$userItems = base.$elem.children().filter(':not(.owl-hidden)');
             base.itemsAmount = base.$userItems.length;
             base.wrapItems();
             base.$owlItems = base.$elem.find(".owl-item");


### PR DESCRIPTION
### Purpose
When using a filtering system to hide elements on desktop, using the same system on mobile does not have the desired results. By altering the items to be included and `reinit()`'ing the plugin the desired elements are hidden without being removed.

### Example
    $('.selector').owlCarousel();

    // replace with own functionality to select required elements and add class
    setTimeout(function(){
        //add class to child elements to hide
        $('.selector > *:nth-child(even)').addClass('.owl-hidden');

        $('.selector').data('owlCarousel').reinit();
    },1500)