### PR TITLE
Export Carousel Class to public

### DIFF
--- a/owl-carousel/owl.carousel.js
+++ b/owl-carousel/owl.carousel.js
@@ -1454,6 +1454,8 @@ if (typeof Object.create !== "function") {
         });
     };
 
+    $.fn.owlCarousel.Constructor = Carousel;
+
     $.fn.owlCarousel.options = {
 
         items : 5,


### PR DESCRIPTION
Especially as Owl 1.x ages, it would be helpful for those with content still on 1.x to be able to apply patches to the classes methods.

For instance, Owl can be integrated with ReactJS if you are careful to:
* Always destroy owl before running, which will restore the DOM state that React expects, therefor…
* Avoid re-rendering with `shouldComponentUpdate`.
* Re-init as needed on `componentDidMount` and `componentDidUpdate`.

I'd like to wrap Owl in a React component, initally with those rules, and then slowly cut-out some of Owl's DOM manipulation, with a modified Owl.