### PR TITLE
Fix to allow dynamic creation of carousels

### DIFF
--- a/owl-carousel/owl.carousel.js
+++ b/owl-carousel/owl.carousel.js
@@ -1445,7 +1445,7 @@ if (typeof Object.create !== "function") {
     $.fn.owlCarousel = function (options) {
         return this.each(function () {
             if ($(this).data("owl-init") === true) {
-                return false;
+                return;
             }
             $(this).data("owl-init", true);
             var carousel = Object.create(Carousel);


### PR DESCRIPTION
If you return "false" from within the callback function it stops the loop. This breaks the creation of new dynamic carousels for elements that are selected by class (or any other selector that returns more than one element).