### PR TITLE
Fix issue where all resize handlers were cleared even though not set

### DIFF
--- a/owl-carousel/owl.carousel.js
+++ b/owl-carousel/owl.carousel.js
@@ -1362,7 +1362,9 @@ if (typeof Object.create !== "function") {
             var base = this;
             base.$elem.off(".owl owl mousedown.disableTextSelect");
             $(document).off(".owl owl");
-            $(window).off("resize", base.resizer);
+            if (base.resizer) {
+              $(window).off("resize", base.resizer);
+            }
         },
 
         unWrap : function () {


### PR DESCRIPTION
Tried handling resize in application, but application resize handler was being cleared.

(I haven't seen/found the procedure to generate the minimized version)