### PR TITLE
Update owl.carousel.css

### DIFF
--- a/owl-carousel/owl.carousel.css
+++ b/owl-carousel/owl.carousel.css
@@ -32,7 +32,6 @@
 .owl-carousel .owl-wrapper-outer.autoHeight{
 	-webkit-transition: height 500ms ease-in-out;
 	-moz-transition: height 500ms ease-in-out;
-	-ms-transition: height 500ms ease-in-out;
 	-o-transition: height 500ms ease-in-out;
 	transition: height 500ms ease-in-out;
 }
@@ -63,9 +62,9 @@
 .owl-carousel  .owl-item{
 	-webkit-backface-visibility: hidden;
 	-moz-backface-visibility:    hidden;
-	-ms-backface-visibility:     hidden;
+	backface-visibility:     hidden;
   -webkit-transform: translate3d(0,0,0);
   -moz-transform: translate3d(0,0,0);
   -ms-transform: translate3d(0,0,0);
+  transform: translate3d(0,0,0);
 }
-


### PR DESCRIPTION
IE10 does not support -ms-transition anymore
Replaced -ms-backface-visibility with default version
Added missing default for transform