### PR TITLE
Allow other carousels to be initialized

### DIFF
--- a/owl-carousel/owl.carousel.js
+++ b/owl-carousel/owl.carousel.js
@@ -1445,7 +1445,7 @@ if (typeof Object.create !== "function") {
     $.fn.owlCarousel = function (options) {
         return this.each(function () {
             if ($(this).data("owl-init") === true) {
-                return false;
+                return true;
             }
             $(this).data("owl-init", true);
             var carousel = Object.create(Carousel);


### PR DESCRIPTION
In the JQuery helper function, allow all carousel elements to be evaluated even if you come across one that has been previously initialized.