### PR TITLE
Fixed typo in demo-options

### DIFF
--- a/index.html
+++ b/index.html
@@ -736,7 +736,7 @@ $("#owl-example").owlCarousel({
     beforeMove: false, 
     afterMove: false,
     afterAction: false,
-    startDragging : false
+    startDragging : false,
     afterLazyLoad : false
 
 })


### PR DESCRIPTION
This should fix an initial error when copy-pasting the default options.